### PR TITLE
Sporadic test fail

### DIFF
--- a/app/forms/register/establishers/individual/ContactDetailsFormProvider.scala
+++ b/app/forms/register/establishers/individual/ContactDetailsFormProvider.scala
@@ -33,11 +33,18 @@ class ContactDetailsFormProvider @Inject() extends Mappings {
    def apply(): Form[ContactDetails] = Form(
      mapping(
       "emailAddress" -> text("messages__error__email").verifying(
-        returnOnFirstFailure(regexp(emailRegex, "messages__error__email_invalid"),
-        maxLength(maxEmailLength, "messages__error__email_length"))),
-      "phoneNumber" -> text("messages__error__phone").verifying(returnOnFirstFailure(
-        regexp(regexPhoneNumber, "messages__error__phone_invalid"),
-        maxLength(maxLengthPhone, "messages__error__phone_length")))
+        returnOnFirstFailure(
+          maxLength(maxEmailLength, "messages__error__email_length"),
+          regexp(emailRegex, "messages__error__email_invalid")
+        )
+      ),
+      "phoneNumber" -> text("messages__error__phone").verifying(
+        returnOnFirstFailure(
+          maxLength(maxLengthPhone, "messages__error__phone_length"),
+          regexp(regexPhoneNumber, "messages__error__phone_invalid")
+        )
+      )
     )(ContactDetails.apply)(ContactDetails.unapply)
    )
- }
+
+}

--- a/test/forms/register/establishers/individual/ContactDetailsFormProviderSpec.scala
+++ b/test/forms/register/establishers/individual/ContactDetailsFormProviderSpec.scala
@@ -50,7 +50,7 @@ class ContactDetailsFormProviderSpec extends FormBehaviours {
 
     "fail to bind when email exceeds max length 132" in {
       val maxlengthEmail = 132
-      val testString = s"${RandomStringUtils.random(50)}@${RandomStringUtils.random(83)}"
+      val testString = s"${RandomStringUtils.random(50)}@${RandomStringUtils.random(82)}"
       val data = validData + ("emailAddress" -> testString)
 
       val expectedError = error("emailAddress", "messages__error__email_length", maxlengthEmail)
@@ -67,7 +67,7 @@ class ContactDetailsFormProviderSpec extends FormBehaviours {
     }
 
     "fail to bind when phoneNumber exceeds max length 24" in {
-      val invalidPhoneNumber = "1234457657655576576575647467"
+      val invalidPhoneNumber = "1234567890123456789012345"
       val maxlengthPhone = 24
       val data = validData + ("phoneNumber" -> invalidPhoneNumber)
 
@@ -75,4 +75,5 @@ class ContactDetailsFormProviderSpec extends FormBehaviours {
       checkForError(form, data, expectedError)
     }
   }
+
 }


### PR DESCRIPTION
Non-deterministic test caused by random string generation for email addresses. Random string characters failed regex validation. Switched validation to test length first.