### PR TITLE
Non-deterministic test issue with email mapping

### DIFF
--- a/test/forms/behaviours/EmailBehaviours.scala
+++ b/test/forms/behaviours/EmailBehaviours.scala
@@ -33,7 +33,7 @@ trait EmailBehaviours extends FormSpec with StringFieldBehaviours with Constrain
   ): Unit = {
 
     "behave like a form with an email field" should {
-      val testRegexString = """^[^@<>]{1,65}@[^@<>]{1,65}$"""
+      val testRegexString = """^[^@<>‘“]{1,65}@[^@<>‘“]{1,65}$"""
 
       behave like fieldThatBindsValidData(
         form,


### PR DESCRIPTION
The regex for email was different in spec and mapping. The mapping regex is correct. The difference led to occasional invalid email address values being used to bind data.