### PR TITLE
PODS-2428: Logic for trustee section where scheme type is not single/master trust

### DIFF
--- a/app/utils/HsTaskListHelper.scala
+++ b/app/utils/HsTaskListHelper.scala
@@ -19,12 +19,13 @@ package utils
 import identifiers.register.establishers.company.{CompanyDetailsId => EstablisherCompanyDetailsId}
 import identifiers.register.establishers.individual.EstablisherDetailsId
 import identifiers.register.establishers.partnership.{PartnershipDetailsId => EstablisherPartnershipDetailsId}
-import identifiers.register.trustees.MoreThanTenTrusteesId
+import identifiers.register.trustees.{MoreThanTenTrusteesId, TrusteeKindId}
 import identifiers.register.trustees.company.{CompanyDetailsId => TrusteeCompanyDetailsId}
 import identifiers.register.trustees.individual.TrusteeDetailsId
 import identifiers.register.trustees.partnership.{PartnershipDetailsId => TrusteePartnershipDetailsId}
 import identifiers.{DeclarationDutiesId, IsWorkingKnowledgeCompleteId, _}
-import models.register.Entity
+import models.register.{Entity, SchemeType}
+import models.register.SchemeType.{MasterTrust, SingleTrust}
 import models.{Link, Mode, NormalMode}
 import play.api.i18n.Messages
 import viewmodels._
@@ -42,7 +43,11 @@ abstract class HsTaskListHelper(answers: UserAnswers)(implicit messages: Message
   protected lazy val individualLinkText = messages("messages__schemeTaskList__individual_link")
   protected lazy val partnershipLinkText = messages("messages__schemeTaskList__partnership_link")
   protected lazy val addTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_add_link")
+  protected lazy val addDeleteTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_add_delete_link")
+  protected lazy val addTrusteesAdditionalInfo = messages("messages__schemeTaskList__sectionTrustees_add_additional_text")
   protected lazy val changeTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_change_link")
+  protected lazy val deleteTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_delete_link")
+  protected lazy val deleteTrusteesAdditionalInfo = messages("messages__schemeTaskList__sectionTrustees_delete_additional_text")
   protected lazy val declarationLinkText = messages("messages__schemeTaskList__declaration_link")
 
   def taskList: SchemeDetailsTaskList
@@ -83,30 +88,47 @@ abstract class HsTaskListHelper(answers: UserAnswers)(implicit messages: Message
 
   private[utils] def addTrusteeHeader(userAnswers: UserAnswers, mode: Mode, srn: Option[String]): Option[SchemeDetailsTaskListSection] = {
     userAnswers.get(HaveAnyTrusteesId) match {
-      case None | Some(true) =>
-        if (userAnswers.allTrusteesAfterDelete.nonEmpty) {
-          Some(
-            SchemeDetailsTaskListSection(
-              Some(isAllTrusteesCompleted(userAnswers)),
-              Link(changeTrusteesLinkText,
-                controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url),
-              None
-            )
+      case None | Some(true) if userAnswers.allTrusteesAfterDelete.nonEmpty =>
+        val (linkText, additionalText): (String, Option[String]) =
+          getTrusteeHeaderText(userAnswers.allTrusteesAfterDelete.size, userAnswers.get(SchemeTypeId))
+
+        Some(
+          SchemeDetailsTaskListSection(
+            None,
+            Link(linkText,
+              controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None, additionalText
           )
-        } else {
-          Some(
-            SchemeDetailsTaskListSection(None,
-              Link(addTrusteesLinkText,
-                controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, userAnswers.allTrustees.size, srn).url),
-              None
-            )
-          )
+        )
+      case None | Some(true) if userAnswers.allTrusteesAfterDelete.isEmpty =>
+
+        val isAllTrusteesCompletedStatus: Option[Boolean] = (isAllTrusteesCompleted(userAnswers), trusteesMandatory(userAnswers.get(SchemeTypeId))) match {
+          case (true, _) => None
+          case (false, false) => None
+          case (false, true) => Some(false)
         }
+
+        Some(
+          SchemeDetailsTaskListSection(
+            isAllTrusteesCompletedStatus,
+            Link(addTrusteesLinkText,
+              controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, userAnswers.allTrustees.size, srn).url), None, None
+          )
+        )
       case _ =>
         None
     }
   }
 
+  private[utils] def getTrusteeHeaderText(size: Int, schemeType: Option[SchemeType]): (String, Option[String]) = size match {
+    case `size` if size == 10 => (deleteTrusteesLinkText, Some(deleteTrusteesAdditionalInfo))
+    case `size` if size == 1 && trusteesMandatory(schemeType) => (addTrusteesLinkText, Some(addTrusteesAdditionalInfo))
+    case `size` if size > 1 && size < 10 => (addDeleteTrusteesLinkText, None)
+    case _ => (changeTrusteesLinkText, None)
+  }
+
+  private[utils] def trusteesMandatory(schemeType: Option[SchemeType]): Boolean = {
+    schemeType.contains(MasterTrust) || schemeType.contains(SingleTrust)
+  }
 
   private[utils] def declarationEnabled(userAnswers: UserAnswers): Boolean = {
     val isTrusteeOptional = userAnswers.get(HaveAnyTrusteesId).contains(false)
@@ -136,7 +158,7 @@ abstract class HsTaskListHelper(answers: UserAnswers)(implicit messages: Message
     case EstablisherPartnershipDetailsId(_) | TrusteePartnershipDetailsId(_) => partnershipLinkText
   }
 
-    protected def linkTarget(item: Entity[_], index: Int, mode: Mode, srn: Option[String]): String = {
+  protected def linkTarget(item: Entity[_], index: Int, mode: Mode, srn: Option[String]): String = {
     item match {
       case models.register.EstablisherCompanyEntity(_, _, _, true, _, _) =>
         controllers.register.establishers.company.routes.CompanyReviewController.onPageLoad(mode, srn, index).url

--- a/app/viewmodels/SchemeDetailsTaskList.scala
+++ b/app/viewmodels/SchemeDetailsTaskList.scala
@@ -45,7 +45,7 @@ object SchemeDetailsTaskList {
   implicit val formats: OFormat[SchemeDetailsTaskList] = Json.format[SchemeDetailsTaskList]
 }
 
-case class SchemeDetailsTaskListSection(isCompleted: Option[Boolean] = None, link: Link, header: Option[String] = None, paragraphOne: Option[String] = None)
+  case class SchemeDetailsTaskListSection(isCompleted: Option[Boolean] = None, link: Link, header: Option[String] = None, p1: Option[String] = None)
 
 object SchemeDetailsTaskListSection {
   implicit val formats: OFormat[SchemeDetailsTaskListSection] = Json.format[SchemeDetailsTaskListSection]

--- a/app/viewmodels/SchemeDetailsTaskList.scala
+++ b/app/viewmodels/SchemeDetailsTaskList.scala
@@ -45,7 +45,7 @@ object SchemeDetailsTaskList {
   implicit val formats: OFormat[SchemeDetailsTaskList] = Json.format[SchemeDetailsTaskList]
 }
 
-case class SchemeDetailsTaskListSection(isCompleted: Option[Boolean] = None, link: Link, header: Option[String] = None)
+case class SchemeDetailsTaskListSection(isCompleted: Option[Boolean] = None, link: Link, header: Option[String] = None, paragraphOne: Option[String] = None)
 
 object SchemeDetailsTaskListSection {
   implicit val formats: OFormat[SchemeDetailsTaskListSection] = Json.format[SchemeDetailsTaskListSection]

--- a/app/views/schemeDetailsTaskList.scala.html
+++ b/app/views/schemeDetailsTaskList.scala.html
@@ -176,7 +176,7 @@
                     @messages(header.link.text)
                 </a>
 
-                @header.paragraphOne.map { text =>
+                @header.p1.map { text =>
                     <p id="section-trustees-header-additional-text">@text</p>
                 }
 

--- a/app/views/schemeDetailsTaskList.scala.html
+++ b/app/views/schemeDetailsTaskList.scala.html
@@ -170,9 +170,15 @@
                 </h2>
 
                 @variationsOnly("<p>")
+
+                <!--this is the add link-->
                 <a id= "section-trustees-link"  href="@{header.link.target}">
                     @messages(header.link.text)
                 </a>
+
+                @header.paragraphOne.map { text =>
+                    <p id="section-trustees-header-additional-text">@text</p>
+                }
 
                 @header.isCompleted.map{ isCompleted =>
                     <strong class="@statusClass(isCompleted)" id="section-trustees-status">@messages(status(isCompleted))</strong>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1152,8 +1152,13 @@ messages__schemeTaskList__sectionEstablishers_add_link = Add establishers
 messages__schemeTaskList__sectionEstablishers_change_link = Change establishers
 
 messages__schemeTaskList__sectionTrustees_header = Trustees
-messages__schemeTaskList__sectionTrustees_add_link = Add trustees
+messages__schemeTaskList__sectionTrustees_add_link = Add a trustee
+messages__schemeTaskList__sectionTrustees_add_additional_text = There must be a minimum of 1 trustee. If you want to remove this trustee, you must first add a new one.
 messages__schemeTaskList__sectionTrustees_change_link = Change trustees
+
+messages__schemeTaskList__sectionTrustees_add_delete_link = Add or delete a trustee
+messages__schemeTaskList__sectionTrustees_delete_link = Delete a trustee
+messages__schemeTaskList__sectionTrustees_delete_additional_text = A maximum of 10 trustees can be added. If you want to add another trustee, you must first delete an existing one.
 
 messages__schemeTaskList__sectionWorkingKnowledge_header = Working knowledge of pensions
 

--- a/test/utils/behaviours/HsTaskListHelperBehaviour.scala
+++ b/test/utils/behaviours/HsTaskListHelperBehaviour.scala
@@ -32,6 +32,7 @@ import identifiers.register.trustees.{IsTrusteeCompleteId, MoreThanTenTrusteesId
 import identifiers.{IsWorkingKnowledgeCompleteId, _}
 import models._
 import models.person.PersonDetails
+import models.register.SchemeType
 import org.joda.time.LocalDate
 import org.scalatest.{MustMatchers, OptionValues}
 import play.api.libs.json.JsResult
@@ -54,7 +55,12 @@ trait HsTaskListHelperBehaviour extends SpecBase with MustMatchers with OptionVa
   protected lazy val individualLinkText = messages("messages__schemeTaskList__individual_link")
   protected lazy val partnershipLinkText = messages("messages__schemeTaskList__partnership_link")
   protected lazy val addTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_add_link")
+  protected lazy val addTrusteesAdditionalInfo = messages("messages__schemeTaskList__sectionTrustees_add_additional_text")
   protected lazy val changeTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_change_link")
+  protected lazy val addDeleteTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_add_delete_link")
+  protected lazy val deleteTrusteesLinkText = messages("messages__schemeTaskList__sectionTrustees_delete_link")
+  protected lazy val deleteTrusteesAdditionalInfo = messages("messages__schemeTaskList__sectionTrustees_delete_additional_text")
+
   protected lazy val declarationLinkText = messages("messages__schemeTaskList__declaration_link")
 
 
@@ -197,7 +203,59 @@ trait HsTaskListHelperBehaviour extends SpecBase with MustMatchers with OptionVa
     }
   }
 
+  //scalastyle:off method.length
   def addTrusteeHeader(mode: Mode , srn: Option[String]): Unit = {
+
+    "display correct link data when 2 trustees exist " in {
+      val userAnswers = UserAnswers()
+        .set(TrusteeDetailsId(0))(PersonDetails("firstName", None, "lastName", LocalDate.now())).flatMap(
+        _.set(IsTrusteeCompleteId(0))(true)).asOpt.value
+        .set(TrusteeDetailsId(1))(PersonDetails("firstName", None, "lastName", LocalDate.now())).flatMap(
+        _.set(IsTrusteeCompleteId(1))(true)).asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
+        SchemeDetailsTaskListSection(None, Link(addDeleteTrusteesLinkText,
+          controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None)
+    }
+
+    "display correct link data when trustee is optional and no trustee exists " in {
+      val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(true).asOpt.value
+        .set(SchemeTypeId)(SchemeType.BodyCorporate).asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
+        SchemeDetailsTaskListSection(None, Link(addTrusteesLinkText,
+          controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, userAnswers.allTrustees.size, srn).url), None, None)
+    }
+
+    "display correct link data when trustee is mandatory and no trustees exists " in {
+      val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(true).asOpt.value
+        .set(SchemeTypeId)(SchemeType.MasterTrust).asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
+        SchemeDetailsTaskListSection(Some(false), Link(addTrusteesLinkText,
+          controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, userAnswers.allTrustees.size, srn).url), None,
+          None)
+    }
+
+    "display correct link data when trustee is mandatory and 1 trustee exists " in {
+      val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(true).asOpt.value
+        .set(TrusteeDetailsId(0))(PersonDetails("firstName", None, "lastName", LocalDate.now())).flatMap(
+        _.set(IsTrusteeCompleteId(0))(true)).asOpt.value
+        .set(SchemeTypeId)(SchemeType.MasterTrust).asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
+        SchemeDetailsTaskListSection(None, Link(addTrusteesLinkText,
+          controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None, Some(addTrusteesAdditionalInfo))
+    }
+
+    "display correct link data when 10 trustees exist " in {
+      val userAnswers = answersDataWithTenTrustees().asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
+        SchemeDetailsTaskListSection(None, Link(deleteTrusteesLinkText,
+          controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None,
+          Some(deleteTrusteesAdditionalInfo))
+    }
 
     "not display when do you have any trustees is false " in {
       val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(false).asOpt.value
@@ -213,14 +271,14 @@ trait HsTaskListHelperBehaviour extends SpecBase with MustMatchers with OptionVa
           controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, userAnswers.allTrustees.size, srn).url), None)
     }
 
-    "display and link should go to add trustees page and status is completed when do you have any trustees is not present" +
+    "display and link should go to add trustees page when do you have any trustees is not present" +
       "and trustees are added and completed" in {
       val userAnswers = UserAnswers().set(TrusteeDetailsId(0))(PersonDetails("firstName", None, "lastName", LocalDate.now())).flatMap(
         _.set(IsTrusteeCompleteId(0))(true)
       ).asOpt.value
       val helper = createTaskListHelper(userAnswers)
       helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
-        SchemeDetailsTaskListSection(Some(true), Link(changeTrusteesLinkText,
+        SchemeDetailsTaskListSection(None, Link(changeTrusteesLinkText,
           controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None)
     }
 
@@ -231,7 +289,7 @@ trait HsTaskListHelperBehaviour extends SpecBase with MustMatchers with OptionVa
       ).asOpt.value
       val helper = createTaskListHelper(userAnswers)
       helper.addTrusteeHeader(userAnswers, mode, srn).value mustBe
-        SchemeDetailsTaskListSection(Some(false), Link(changeTrusteesLinkText,
+        SchemeDetailsTaskListSection(None, Link(changeTrusteesLinkText,
           controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url), None)
     }
   }

--- a/test/views/SchemeDetailsTaskListViewSpec.scala
+++ b/test/views/SchemeDetailsTaskListViewSpec.scala
@@ -187,21 +187,21 @@ class SchemeDetailsTaskListViewSpec extends ViewBehaviours {
 
     "no trustees" should {
 
-      val journeyTaskListNoTrustees: SchemeDetailsTaskList = SchemeDetailsTaskList(beforeYouStartSection,"test", Seq.empty, None,
+      def journeyTaskListNoTrustees(text: Option[String] = None): SchemeDetailsTaskList = SchemeDetailsTaskList(beforeYouStartSection, "test", Seq.empty, None,
         SchemeDetailsTaskListSection(
           None,
           Link(messages("messages__schemeTaskList__sectionEstablishers_add_link"),
             controllers.register.establishers.routes.EstablisherKindController.onPageLoad(NormalMode, 0, None).url),
-          None
-        ), Seq.empty,
+            None), Seq.empty,
         Some(SchemeDetailsTaskListSection(
           None,
           Link(messages("messages__schemeTaskList__sectionTrustees_add_link"),
             controllers.register.trustees.routes.TrusteeKindController.onPageLoad(NormalMode, 0, None).url),
-          None
-        )), Seq.empty, None, "h1", "h2",None, "pageTitle"
+            None,
+          text)), Seq.empty, None, "h1", "h2",None, "pageTitle"
       )
-      val view = createView(journeyTaskListNoTrustees)
+
+      val view = createView(journeyTaskListNoTrustees())
 
       "display correct header" in {
 
@@ -210,12 +210,21 @@ class SchemeDetailsTaskListViewSpec extends ViewBehaviours {
       }
 
       "display the correct link" in {
+        val doc = asDocument(view())
         view must haveLinkWithText(
           url = controllers.register.trustees.routes.TrusteeKindController.onPageLoad(NormalMode, 0, None).url,
           linkText = messages("messages__schemeTaskList__sectionTrustees_add_link"),
           linkId = "section-trustees-link"
         )
+        assertNotRenderedById(doc, id = "section-trustees-header-additional-text")
       }
+
+      "display additional text" in {
+        val view = createView(journeyTaskListNoTrustees(Some("additional text")))
+        val doc = asDocument(view())
+        assertRenderedByIdWithText(doc, id = "section-trustees-header-additional-text", text = "additional text")
+      }
+
     }
 
     "trustees defined and not completed" should {


### PR DESCRIPTION
This work is to display relevant link text for trustees based on how many they have added and if trustees are mandatory (based on scheme type). I've added additional comments to the story to explain test scenarios.