### PR TITLE
PODS-2428: Move addTrusteeHeader into subclasses

### DIFF
--- a/app/utils/HsTaskListHelper.scala
+++ b/app/utils/HsTaskListHelper.scala
@@ -86,38 +86,15 @@ abstract class HsTaskListHelper(answers: UserAnswers)(implicit messages: Message
     }
   }
 
-  private[utils] def addTrusteeHeader(userAnswers: UserAnswers, mode: Mode, srn: Option[String]): Option[SchemeDetailsTaskListSection] = {
-    (userAnswers.get(HaveAnyTrusteesId), userAnswers.allTrusteesAfterDelete.isEmpty) match {
-      case (None | Some(true), false) =>
+  protected[utils] def addTrusteeHeader(userAnswers: UserAnswers, mode: Mode, srn: Option[String]): Option[SchemeDetailsTaskListSection]
 
-        val (linkText, additionalText): (String, Option[String]) =
-          getTrusteeHeaderText(userAnswers.allTrusteesAfterDelete.size, userAnswers.get(SchemeTypeId))
-
-        Some(
-          SchemeDetailsTaskListSection(
-            link = addTrusteeLink(linkText, srn, mode),
-            p1 = additionalText))
-
-      case (None | Some(true), true) =>
-
-        Some(
-          SchemeDetailsTaskListSection(
-            trusteeStatus(isAllTrusteesCompleted(userAnswers), trusteesMandatory(userAnswers.get(SchemeTypeId))),
-            typeOfTrusteeLink(addTrusteesLinkText, userAnswers.allTrustees.size, srn, mode)))
-
-      case _ =>
-        None
-    }
-
-  }
-
-  private def typeOfTrusteeLink(linkText: String, trusteeCount: Int, srn: Option[String], mode: Mode): Link =
+  protected def typeOfTrusteeLink(linkText: String, trusteeCount: Int, srn: Option[String], mode: Mode): Link =
     Link(linkText, controllers.register.trustees.routes.TrusteeKindController.onPageLoad(mode, trusteeCount, srn).url)
 
-  private def addTrusteeLink(linkText: String, srn: Option[String], mode: Mode): Link =
+  protected def addTrusteeLink(linkText: String, srn: Option[String], mode: Mode): Link =
     Link(linkText, controllers.register.trustees.routes.AddTrusteeController.onPageLoad(mode, srn).url)
 
-  private[utils] def trusteeStatus(completed: Boolean, mandatory: Boolean): Option[Boolean] = (completed, mandatory) match {
+  protected[utils] def trusteeStatus(completed: Boolean, mandatory: Boolean): Option[Boolean] = (completed, mandatory) match {
     case (true, _) => None
     case (false, false) => None
     case (false, true) => Some(false)

--- a/app/utils/HsTaskListHelperRegistration.scala
+++ b/app/utils/HsTaskListHelperRegistration.scala
@@ -16,9 +16,9 @@
 
 package utils
 
-import identifiers.{IsAboutBankDetailsCompleteId, IsAboutBenefitsAndInsuranceCompleteId, IsAboutMembersCompleteId}
+import identifiers._
 import models.register.Entity
-import models.{Link, NormalMode}
+import models.{Link, Mode, NormalMode}
 import play.api.i18n.Messages
 import viewmodels._
 
@@ -69,6 +69,31 @@ class HsTaskListHelperRegistration(answers: UserAnswers)(implicit messages: Mess
 
   protected[utils] def trustees(userAnswers: UserAnswers): Seq[SchemeDetailsTaskListSection] =
     listOf(userAnswers.allTrustees, userAnswers)
+
+  protected[utils] override def addTrusteeHeader(userAnswers: UserAnswers, mode: Mode, srn: Option[String]): Option[SchemeDetailsTaskListSection] = {
+    (userAnswers.get(HaveAnyTrusteesId), userAnswers.allTrusteesAfterDelete.isEmpty) match {
+      case (None | Some(true), false) =>
+
+        val (linkText, additionalText): (String, Option[String]) =
+          getTrusteeHeaderText(userAnswers.allTrusteesAfterDelete.size, userAnswers.get(SchemeTypeId))
+
+        Some(
+          SchemeDetailsTaskListSection(
+            link = addTrusteeLink(linkText, srn, mode),
+            p1 = additionalText))
+
+      case (None | Some(true), true) =>
+
+        Some(
+          SchemeDetailsTaskListSection(
+            trusteeStatus(isAllTrusteesCompleted(userAnswers), trusteesMandatory(userAnswers.get(SchemeTypeId))),
+            typeOfTrusteeLink(addTrusteesLinkText, userAnswers.allTrustees.size, srn, mode)))
+
+      case _ =>
+        None
+    }
+
+  }
 
   def taskList: SchemeDetailsTaskList = {
     SchemeDetailsTaskList(

--- a/app/utils/HsTaskListHelperVariations.scala
+++ b/app/utils/HsTaskListHelperVariations.scala
@@ -19,7 +19,7 @@ package utils
 import identifiers.register.trustees.MoreThanTenTrusteesId
 import identifiers.{IsAboutBenefitsAndInsuranceCompleteId, IsAboutMembersCompleteId, SchemeNameId, _}
 import models.register.Entity
-import models.{Link, UpdateMode}
+import models.{Link, Mode, UpdateMode}
 import play.api.i18n.Messages
 import viewmodels._
 
@@ -81,6 +81,24 @@ class HsTaskListHelperVariations(answers: UserAnswers, viewOnly: Boolean, srn: O
       Some(isTrusteeOptional | isAllTrusteesCompleted(userAnswers)),
       Some(userAnswers.allTrusteesAfterDelete.size < 10 || userAnswers.get(MoreThanTenTrusteesId).isDefined)
     ).forall(_.contains(true)) && userAnswers.isUserAnswerUpdated()
+  }
+
+  protected[utils] override def addTrusteeHeader(userAnswers: UserAnswers, mode: Mode, srn: Option[String]): Option[SchemeDetailsTaskListSection] = {
+    if (userAnswers.allTrusteesAfterDelete.isEmpty) {
+      Some(
+        SchemeDetailsTaskListSection(
+          trusteeStatus(isAllTrusteesCompleted(userAnswers), trusteesMandatory(userAnswers.get(SchemeTypeId))),
+          typeOfTrusteeLink(addTrusteesLinkText, userAnswers.allTrustees.size, srn, mode)))
+    } else {
+      val (linkText, additionalText): (String, Option[String]) =
+        getTrusteeHeaderText(userAnswers.allTrusteesAfterDelete.size, userAnswers.get(SchemeTypeId))
+
+      Some(
+        SchemeDetailsTaskListSection(
+          link = addTrusteeLink(linkText, srn, mode),
+          p1 = additionalText))
+    }
+
   }
 
   def taskList: SchemeDetailsTaskList = {

--- a/test/utils/HsTaskListHelperRegistrationSpec.scala
+++ b/test/utils/HsTaskListHelperRegistrationSpec.scala
@@ -162,6 +162,13 @@ class HsTaskListHelperRegistrationSpec extends HsTaskListHelperBehaviour with En
   "addTrusteeHeader " must {
 
     behave like addTrusteeHeader(NormalMode, None)
+
+    "not display when do you have any trustees is false " in {
+      val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(false).asOpt.value
+      val helper = createTaskListHelper(userAnswers)
+      helper.addTrusteeHeader(userAnswers, NormalMode, Some("srn")) mustBe None
+    }
+
   }
 
   "establishers" must {

--- a/test/utils/behaviours/HsTaskListHelperBehaviour.scala
+++ b/test/utils/behaviours/HsTaskListHelperBehaviour.scala
@@ -257,12 +257,6 @@ trait HsTaskListHelperBehaviour extends SpecBase with MustMatchers with OptionVa
           Some(deleteTrusteesAdditionalInfo))
     }
 
-    "not display when do you have any trustees is false " in {
-      val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(false).asOpt.value
-      val helper = createTaskListHelper(userAnswers)
-      helper.addTrusteeHeader(userAnswers, mode, srn) mustBe None
-    }
-
     "display and link should go to trustee kind page when do you have any trustees is true and no trustees are added " in {
       val userAnswers = UserAnswers().set(HaveAnyTrusteesId)(true).asOpt.value
       val helper = createTaskListHelper(userAnswers)


### PR DESCRIPTION
Refactored to put the method into registration/variation class. Checked the pensions-scheme back end and the schemeType is getting pulled through so no  changes needed.