### PR TITLE
PODS-2711: Create generic controller and view for CRN

### DIFF
--- a/app/controllers/register/CompanyRegistrationNumberBaseController.scala
+++ b/app/controllers/register/CompanyRegistrationNumberBaseController.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register
+
+import config.FrontendAppConfig
+import controllers.Retrievals
+import controllers.actions._
+import forms.CompanyRegistrationNumberFormProvider
+import identifiers.TypedIdentifier
+import identifiers.register.establishers.company.CompanyRegistrationNumberId
+import javax.inject.Inject
+import models.requests.DataRequest
+import models.{CompanyRegistrationNumber, Index, Mode}
+import play.api.data.Form
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, Call}
+import play.twirl.api.Html
+import services.UserAnswersService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import utils._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+abstract class CompanyRegistrationNumberBaseController @Inject()(
+                                                           appConfig: FrontendAppConfig,
+                                                           override val messagesApi: MessagesApi,
+                                                           userAnswersService: UserAnswersService,
+                                                           navigator: Navigator,
+                                                           authenticate: AuthAction,
+                                                           getData: DataRetrievalAction,
+                                                           allowAccess: AllowAccessActionProvider,
+                                                           requireData: DataRequiredAction,
+                                                           formProvider: CompanyRegistrationNumberFormProvider
+                                                         )(implicit val ec: ExecutionContext) extends FrontendController with Retrievals with I18nSupport with Enumerable.Implicits with MapFormats {
+
+  val form = formProvider()
+
+  def addView(mode: Mode, index: Index, srn: Option[String])(implicit request: DataRequest[AnyContent]): Html
+
+  def errorView(mode: Mode, index: Index, srn: Option[String], form: Form[_])(implicit request: DataRequest[AnyContent]): Html
+
+  def updateView(mode: Mode, index: Index, srn: Option[String], value: CompanyRegistrationNumber)(implicit request: DataRequest[AnyContent]): Html
+
+  def id(index: Index): TypedIdentifier[CompanyRegistrationNumber]
+
+  def onPageLoad(mode: Mode, srn: Option[String], index: Index): Action[AnyContent] =
+    (authenticate andThen getData(mode, srn) andThen allowAccess(srn) andThen requireData).async {
+      implicit request =>
+        val redirectResult = request.userAnswers.get(id(index)) match {
+          case None =>
+            Ok(addView(mode, index, srn))
+          case Some(value) =>
+            Ok(updateView(mode, index, srn, value))
+        }
+
+        Future.successful(redirectResult)
+    }
+
+  def onSubmit(mode: Mode, srn: Option[String], index: Index): Action[AnyContent] = (authenticate andThen getData(mode, srn) andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        (formWithErrors: Form[_]) =>
+          Future.successful(BadRequest(errorView(mode, index, srn, formWithErrors))),
+        value =>
+          userAnswersService.save(mode, srn, id(index), value).map(cacheMap =>
+            Redirect(navigator.nextPage(id(index), mode, UserAnswers(cacheMap), srn)))
+      )
+  }
+
+  protected def postCall: (Mode, Option[String], Index) => Call
+
+}

--- a/app/controllers/register/establishers/company/CompanyRegistrationNumberUpdateController.scala
+++ b/app/controllers/register/establishers/company/CompanyRegistrationNumberUpdateController.scala
@@ -34,7 +34,7 @@ import views.html.register.establishers.company.companyRegistrationNumber
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class CompanyRegistrationNumberController @Inject()(
+class CompanyRegistrationNumberUpdateController @Inject()(
                                                      val appConfig: FrontendAppConfig,
                                                      override val messagesApi: MessagesApi,
                                                      userAnswersService: UserAnswersService,

--- a/app/controllers/register/establishers/company/CompanyRegistrationNumberUpdateController.scala
+++ b/app/controllers/register/establishers/company/CompanyRegistrationNumberUpdateController.scala
@@ -30,7 +30,7 @@ import play.api.mvc.{AnyContent, Call}
 import services.UserAnswersService
 import utils._
 import utils.annotations.EstablishersCompany
-import views.html.register.establishers.company.companyRegistrationNumber
+import views.html.register.companyRegistrationNumberUpdate
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -48,11 +48,11 @@ class CompanyRegistrationNumberUpdateController @Inject()(
   CompanyRegistrationNumberBaseController(
     appConfig, messagesApi, userAnswersService, navigator, authenticate, getData, allowAccess, requireData, formProvider) {
 
-  override def addView(mode: Mode, index: Index, srn: Option[String])(implicit request: DataRequest[AnyContent]) = companyRegistrationNumber(appConfig, form, mode, index, existingSchemeName, postCall(mode, srn, index), srn)
+  override def addView(mode: Mode, index: Index, srn: Option[String])(implicit request: DataRequest[AnyContent]) = companyRegistrationNumberUpdate(appConfig, form, mode, index, existingSchemeName, postCall(mode, srn, index), srn)
 
-  override def errorView(mode: Mode, index: Index, srn: Option[String], form: Form[_])(implicit request: DataRequest[AnyContent]) = companyRegistrationNumber(appConfig, form, mode, index, existingSchemeName, postCall(mode, srn, index), srn)
+  override def errorView(mode: Mode, index: Index, srn: Option[String], form: Form[_])(implicit request: DataRequest[AnyContent]) = companyRegistrationNumberUpdate(appConfig, form, mode, index, existingSchemeName, postCall(mode, srn, index), srn)
 
-  override def updateView(mode: Mode, index: Index, srn: Option[String], value: CompanyRegistrationNumber)(implicit request: DataRequest[AnyContent]) = companyRegistrationNumber(appConfig, form.fill(value), mode, index, existingSchemeName, postCall(mode, srn, index), srn)
+  override def updateView(mode: Mode, index: Index, srn: Option[String], value: CompanyRegistrationNumber)(implicit request: DataRequest[AnyContent]) = companyRegistrationNumberUpdate(appConfig, form.fill(value), mode, index, existingSchemeName, postCall(mode, srn, index), srn)
 
   override def id(index: Index) = CompanyRegistrationNumberId(index)
 

--- a/app/controllers/register/trustees/company/CheckYourAnswersController.scala
+++ b/app/controllers/register/trustees/company/CheckYourAnswersController.scala
@@ -61,7 +61,7 @@ class CheckYourAnswersController @Inject()(appConfig: FrontendAppConfig,
       val companyPayeRow = CompanyPayeId(index).row(routes.CompanyPayeController.onPageLoad(checkMode(mode), index, srn).url, mode)
 
       val companyRegistrationNumber = CompanyRegistrationNumberId(index).row(
-        routes.CompanyRegistrationNumberController.onPageLoad(checkMode(mode), index, srn).url, mode
+        routes.CompanyRegistrationNumberController.onPageLoad(checkMode(mode), srn, index).url, mode
       )
 
       val companyUtr = CompanyUniqueTaxReferenceId(index).row(

--- a/app/navigators/TrusteesCompanyNavigator.scala
+++ b/app/navigators/TrusteesCompanyNavigator.scala
@@ -50,7 +50,7 @@ class TrusteesCompanyNavigator @Inject()(val dataCacheConnector: UserAnswersCach
         NavigateTo.dontSave(controllers.register.trustees.company.routes.CompanyPayeController.onPageLoad(mode, index, srn))
 
       case CompanyPayeId(index) =>
-        NavigateTo.dontSave(controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onPageLoad(mode, index, srn))
+        NavigateTo.dontSave(controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onPageLoad(mode, srn, index))
 
       case CompanyRegistrationNumberId(index) =>
         NavigateTo.dontSave(controllers.register.trustees.company.routes.CompanyUniqueTaxReferenceController.onPageLoad(mode, index, srn))

--- a/app/views/register/companyRegistrationNumberUpdate.scala.html
+++ b/app/views/register/companyRegistrationNumberUpdate.scala.html
@@ -1,0 +1,58 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.FrontendAppConfig
+@import uk.gov.hmrc.play.views.html._
+@import controllers.register.trustees.company.routes._
+@import models.{Mode,CompanyRegistrationNumber}
+@import play.api.mvc.Call
+
+@(appConfig: FrontendAppConfig, form: Form[_], mode: Mode, index:Index, schemeName: Option[String], submitUrl: Call, srn: Option[String])(implicit request: Request[_], messages: Messages)
+
+    @options = @{
+        CompanyRegistrationNumber.options
+    }
+
+    @main_template(
+        title = messages("messages__companyRegistrationNumber__title"),
+        appConfig = appConfig,
+        bodyClasses = None) {
+
+        @helpers.form(action = submitUrl, 'autoComplete -> "off") {
+
+        @components.error_summary(form.errors)
+
+        @components.heading(
+            headingKey=messages("messages__companyRegistrationNumber__heading")
+        )
+        @components.fieldSet(
+            field = form("companyRegistrationNumber.hasCrn"),
+            hint=Some(messages("messages__common__crn_hint")),
+            legend = "messages__company__has_crn",
+            hiddenLegend = true
+            ) {
+
+            @components.input_text(
+                field = form("companyRegistrationNumber.crn"),
+                label = messages("messages__common__crn"),
+                groupClass = Some("js-hidden panel panel-border-narrow")
+                )
+        }
+        @components.submit_button()
+
+        @components.return_link("messages__schemeTaskList__returnlink", schemeName, None, srn)
+    }
+}

--- a/conf/trustees.routes
+++ b/conf/trustees.routes
@@ -108,12 +108,12 @@ POST       /:index/company/change/how-long-at-address                    control
 GET        /:index/company/:mode/how-long-at-address/:srn               controllers.register.trustees.company.CompanyAddressYearsController.onPageLoad(mode: Mode, index: Index, srn: Option[String])
 POST       /:index/company/:mode/how-long-at-address/:srn               controllers.register.trustees.company.CompanyAddressYearsController.onSubmit(mode: Mode, index: Index, srn: Option[String])
 
-GET        /:index/company/company-registration-number                  controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = NormalMode, index: Index, srn: Option[String] = None)
-POST       /:index/company/company-registration-number                  controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = NormalMode, index: Index, srn: Option[String] = None)
-GET        /:index/company/change/company-registration-number           controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = CheckMode, index: Index, srn: Option[String] = None)
-POST       /:index/company/change/company-registration-number           controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = CheckMode, index: Index, srn: Option[String] = None)
-GET        /:index/company/:mode/company-registration-number/:srn       controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode, index: Index, srn: Option[String])
-POST       /:index/company/:mode/company-registration-number/:srn       controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode, index: Index, srn: Option[String])
+GET        /:index/company/company-registration-number                  controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = NormalMode, srn: Option[String] = None, index: Index)
+POST       /:index/company/company-registration-number                  controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = NormalMode, srn: Option[String] = None, index: Index)
+GET        /:index/company/change/company-registration-number           controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode = CheckMode, srn: Option[String] = None, index: Index)
+POST       /:index/company/change/company-registration-number           controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode = CheckMode, srn: Option[String] = None, index: Index)
+GET        /:index/company/:mode/company-registration-number/:srn       controllers.register.trustees.company.CompanyRegistrationNumberController.onPageLoad(mode: Mode, srn: Option[String], index: Index)
+POST       /:index/company/:mode/company-registration-number/:srn       controllers.register.trustees.company.CompanyRegistrationNumberController.onSubmit(mode: Mode, srn: Option[String], index: Index)
 
 GET        /:index/company/check-your-answers                           controllers.register.trustees.company.CheckYourAnswersController.onPageLoad(mode: Mode = NormalMode, index: Index, srn: Option[String] = None)
 POST       /:index/company/check-your-answers                           controllers.register.trustees.company.CheckYourAnswersController.onSubmit(mode: Mode = NormalMode, index: Index, srn: Option[String] = None)

--- a/test/controllers/register/establishers/company/CompanyRegistrationNumberUpdateControllerSpec.scala
+++ b/test/controllers/register/establishers/company/CompanyRegistrationNumberUpdateControllerSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.register.establishers.company
+
+import controllers.ControllerSpecBase
+import controllers.actions._
+import forms.CompanyRegistrationNumberFormProvider
+import identifiers.register.establishers.EstablishersId
+import identifiers.register.establishers.company.{CompanyDetailsId, CompanyRegistrationNumberId}
+import models._
+import play.api.data.Form
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import services.FakeUserAnswersService
+import utils.FakeNavigator
+import views.html.register.establishers.company.companyRegistrationNumber
+
+class CompanyRegistrationNumberUpdateControllerSpec extends ControllerSpecBase {
+
+  private def onwardRoute = controllers.routes.IndexController.onPageLoad()
+
+  val formProvider = new CompanyRegistrationNumberFormProvider()
+  val form = formProvider()
+  val firstIndex = Index(0)
+  val invalidIndex = Index(3)
+  val companyName = "test company name"
+  private val postCall = routes.CompanyRegistrationNumberController.onSubmit _
+
+  private def controller(dataRetrievalAction: DataRetrievalAction = getMandatoryEstablisherCompany) =
+    new CompanyRegistrationNumberUpdateController(
+      frontendAppConfig,
+      messagesApi,
+      FakeUserAnswersService,
+      new FakeNavigator(desiredRoute = onwardRoute),
+      FakeAuthAction,
+      dataRetrievalAction,
+      FakeAllowAccessProvider(),
+      new DataRequiredActionImpl,
+      formProvider
+    )
+
+  private def viewAsString(form: Form[_] = form) =
+    companyRegistrationNumber(
+      frontendAppConfig,
+      form,
+      NormalMode,
+      firstIndex,
+      None,
+      postCall(NormalMode, None, firstIndex),
+      None
+    )(fakeRequest, messages).toString
+
+  private val validData = Json.obj(
+    EstablishersId.toString -> Json.arr(
+      Json.obj(
+        CompanyDetailsId.toString ->
+          CompanyDetails("test company name"),
+        CompanyRegistrationNumberId.toString ->
+          CompanyRegistrationNumber.Yes("1234567")
+      )
+    )
+  )
+  "CompanyRegistrationNumberUpdateController" must {
+
+    "return OK and the correct view for a GET" in {
+      val result = controller().onPageLoad(NormalMode, None, firstIndex)(fakeRequest)
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe viewAsString()
+    }
+
+    "populate the view correctly on a GET when the question has previously been answered" in {
+      val getRelevantData = new FakeDataRetrievalAction(Some(validData))
+      val result = controller(getRelevantData).onPageLoad(NormalMode, None, firstIndex)(fakeRequest)
+      contentAsString(result) mustBe viewAsString(form.fill(CompanyRegistrationNumber.Yes("1234567")))
+    }
+
+    "redirect to the next page when valid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("companyRegistrationNumber.hasCrn", "true"), ("companyRegistrationNumber.crn", "1234567"))
+      val result = controller().onSubmit(NormalMode, None, firstIndex)(postRequest)
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(onwardRoute.url)
+    }
+
+    "return a Bad Request and errors when invalid data is submitted" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
+      val boundForm = form.bind(Map("value" -> "invalid value"))
+      val result = controller().onSubmit(NormalMode, None, firstIndex)(postRequest)
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) mustBe viewAsString(boundForm)
+    }
+
+    "redirect to Session Expired for a GET if no existing data is found" in {
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode, None, firstIndex)(fakeRequest)
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+
+    "redirect to Session Expired for a POST if no existing data is found" in {
+      val postRequest = fakeRequest.withFormUrlEncodedBody(("value", CompanyRegistrationNumber.options.head.value))
+      val result = controller(dontGetAnyData).onSubmit(NormalMode, None, firstIndex)(postRequest)
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
+    }
+  }
+}

--- a/test/controllers/register/establishers/company/CompanyRegistrationNumberUpdateControllerSpec.scala
+++ b/test/controllers/register/establishers/company/CompanyRegistrationNumberUpdateControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import services.FakeUserAnswersService
 import utils.FakeNavigator
-import views.html.register.establishers.company.companyRegistrationNumber
+import views.html.register.companyRegistrationNumberUpdate
 
 class CompanyRegistrationNumberUpdateControllerSpec extends ControllerSpecBase {
 
@@ -54,7 +54,7 @@ class CompanyRegistrationNumberUpdateControllerSpec extends ControllerSpecBase {
     )
 
   private def viewAsString(form: Form[_] = form) =
-    companyRegistrationNumber(
+    companyRegistrationNumberUpdate(
       frontendAppConfig,
       form,
       NormalMode,

--- a/test/controllers/register/trustees/company/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/register/trustees/company/CheckYourAnswersControllerSpec.scala
@@ -106,7 +106,7 @@ object CheckYourAnswersControllerSpec extends ControllerSpecBase with Controller
   private lazy val companyAddressYearsRoute = routes.CompanyAddressYearsController.onPageLoad(CheckMode, index, None).url
   private lazy val companyDetailsRoute = routes.CompanyDetailsController.onPageLoad(CheckMode, index, None).url
   private lazy val companyPreviousAddressRoute = routes.CompanyPreviousAddressController.onPageLoad(CheckMode, index, None).url
-  private lazy val companyRegistrationNumberRoute = routes.CompanyRegistrationNumberController.onPageLoad(CheckMode, index, None).url
+  private lazy val companyRegistrationNumberRoute = routes.CompanyRegistrationNumberController.onPageLoad(CheckMode, None, index).url
   private lazy val companyUniqueTaxReferenceRoute = routes.CompanyUniqueTaxReferenceController.onPageLoad(CheckMode, index, None).url
 
   private lazy val postUrl = routes.CheckYourAnswersController.onSubmit(NormalMode, index, None)

--- a/test/controllers/register/trustees/company/CompanyRegistrationNumberControllerSpec.scala
+++ b/test/controllers/register/trustees/company/CompanyRegistrationNumberControllerSpec.scala
@@ -73,7 +73,7 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
       new DataRequiredActionImpl,
       formProvider
     )
-  val submitUrl = controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode, index, None)
+  val submitUrl = controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode, None, index)
 
   def viewAsString(form: Form[_] = form): String =
     companyRegistrationNumber(
@@ -89,7 +89,7 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
   "CompanyRegistrationNumber Controller" must {
 
     "return OK and the correct view for a GET" in {
-      val result = controller().onPageLoad(NormalMode, index, None)(fakeRequest)
+      val result = controller().onPageLoad(NormalMode, None, index)(fakeRequest)
 
       status(result) mustBe OK
       contentAsString(result) mustBe viewAsString()
@@ -98,7 +98,7 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
     "populate the view correctly on a GET when the question has previously been answered" in {
       val getRelevantData = new FakeDataRetrievalAction(Some(validData))
 
-      val result = controller(getRelevantData).onPageLoad(NormalMode, index, None)(fakeRequest)
+      val result = controller(getRelevantData).onPageLoad(NormalMode, None, index)(fakeRequest)
 
       contentAsString(result) mustBe viewAsString(form.fill(CompanyRegistrationNumber.Yes("1234567")))
     }
@@ -106,7 +106,7 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
     "redirect to the next page when valid data is submitted" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("companyRegistrationNumber.hasCrn", "true"), ("companyRegistrationNumber.crn", "1234567"))
 
-      val result = controller().onSubmit(NormalMode, index, None)(postRequest)
+      val result = controller().onSubmit(NormalMode, None, index)(postRequest)
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(onwardRoute.url)
@@ -116,14 +116,14 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", "invalid value"))
       val boundForm = form.bind(Map("value" -> "invalid value"))
 
-      val result = controller().onSubmit(NormalMode, index, None)(postRequest)
+      val result = controller().onSubmit(NormalMode, None, index)(postRequest)
 
       status(result) mustBe BAD_REQUEST
       contentAsString(result) mustBe viewAsString(boundForm)
     }
 
     "redirect to Session Expired for a GET if no existing data is found" in {
-      val result = controller(dontGetAnyData).onPageLoad(NormalMode, index, None)(fakeRequest)
+      val result = controller(dontGetAnyData).onPageLoad(NormalMode, None, index)(fakeRequest)
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)
@@ -131,7 +131,7 @@ class CompanyRegistrationNumberControllerSpec extends ControllerSpecBase {
 
     "redirect to Session Expired for a POST if no existing data is found" in {
       val postRequest = fakeRequest.withFormUrlEncodedBody(("value", CompanyRegistrationNumber.options.head.value))
-      val result = controller(dontGetAnyData).onSubmit(NormalMode, index, None)(postRequest)
+      val result = controller(dontGetAnyData).onSubmit(NormalMode, None, index)(postRequest)
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.routes.SessionExpiredController.onPageLoad().url)

--- a/test/navigators/TrusteesCompanyNavigatorSpec.scala
+++ b/test/navigators/TrusteesCompanyNavigatorSpec.scala
@@ -102,7 +102,7 @@ object TrusteesCompanyNavigatorSpec extends SpecBase with OptionValues {
   private def taskList: Call = controllers.routes.SchemeTaskListController.onPageLoad(NormalMode, None)
 
   private def companyRegistrationNumber(mode: Mode): Call =
-    controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onPageLoad(mode, 0, None)
+    controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onPageLoad(mode, None, 0)
 
   private def companyVat(mode: Mode): Call =
     controllers.register.trustees.company.routes.CompanyVatController.onPageLoad(mode, 0, None)

--- a/test/views/register/CompanyRegistrationNumberUpdateViewSpec.scala
+++ b/test/views/register/CompanyRegistrationNumberUpdateViewSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.register
+
+import forms.CompanyRegistrationNumberFormProvider
+import models.{Index, NormalMode, UpdateMode}
+import play.api.data.Form
+import views.behaviours.ViewBehaviours
+import views.html.register.companyRegistrationNumberUpdate
+
+class CompanyRegistrationNumberUpdateViewSpec extends ViewBehaviours {
+
+  val messageKeyPrefix = "companyRegistrationNumber"
+  val index = Index(0)
+  val form = new CompanyRegistrationNumberFormProvider()()
+  val submitUrl = controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode, None, index)
+  private def createView() = () => companyRegistrationNumberUpdate(
+    frontendAppConfig, form, NormalMode, index, None, submitUrl, None)(fakeRequest, messages)
+  private def createUpdateView = () => companyRegistrationNumberUpdate(
+    frontendAppConfig, form, UpdateMode, index, None, submitUrl, Some("srn"))(fakeRequest, messages)
+
+  private def createViewUsingForm = (form: Form[_]) =>
+    companyRegistrationNumberUpdate(frontendAppConfig, form, NormalMode, index, None, submitUrl, None)(fakeRequest, messages)
+
+  "CompanyRegistrationNumber view" when {
+    behave like normalPage(createView(), messageKeyPrefix, messages(s"messages__${messageKeyPrefix}__title"))
+
+    behave like pageWithReturnLink(createView(), getReturnLink)
+
+    behave like pageWithReturnLinkAndSrn(createUpdateView, getReturnLinkWithSrn)
+
+    "Generate correct hint text" in {
+      val doc = asDocument(createView()())
+      assertContainsText(doc, messages("messages__common__crn_hint"))
+    }
+
+    "display an input text box with the value when yes is selected" in {
+      val expectedValue = "1234567"
+      val doc = asDocument(createViewUsingForm(form.bind(Map("companyRegistrationNumber.crn" -> expectedValue))))
+      doc must haveLabelAndValue("companyRegistrationNumber_crn", s"${messages("messages__common__crn")}", expectedValue)
+    }
+
+  }
+}

--- a/test/views/register/trustees/company/CompanyRegistrationNumberViewSpec.scala
+++ b/test/views/register/trustees/company/CompanyRegistrationNumberViewSpec.scala
@@ -27,7 +27,7 @@ class CompanyRegistrationNumberViewSpec extends ViewBehaviours {
   val messageKeyPrefix = "companyRegistrationNumber"
   val index = Index(0)
   val form = new CompanyRegistrationNumberFormProvider()()
-  val submitUrl = controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode, index, None)
+  val submitUrl = controllers.register.trustees.company.routes.CompanyRegistrationNumberController.onSubmit(NormalMode, None, index)
   private def createView() = () => companyRegistrationNumber(
     frontendAppConfig, form, NormalMode, index, None, submitUrl, None)(fakeRequest, messages)
   private def createUpdateView = () => companyRegistrationNumber(


### PR DESCRIPTION
- Created a base controller for CompanyRegistrationNumber
- Added new CompanyRegistrationNumberUpdateController that only shows a text field
- Added a new companyRegistrationNumberUpdate view that only contains a text field
- Refactered CompanyRegistrationNumberController for trustees to it can use base controller